### PR TITLE
Update Reddit auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Reddit API Credentials
 REDDIT_CLIENT_ID=your_reddit_client_id_here
 REDDIT_CLIENT_SECRET=your_reddit_client_secret_here
-REDDIT_USERNAME=your_reddit_username_here
-REDDIT_PASSWORD=your_reddit_password_here
+REDDIT_REFRESH_TOKEN=your_reddit_refresh_token_here
 
 # Supabase Configuration
 SUPABASE_URL=your_supabase_url_here

--- a/API_KEYS_GUIDE.md
+++ b/API_KEYS_GUIDE.md
@@ -108,8 +108,7 @@ python install.py
 **생성 후 필요한 정보**:
 - **Client ID**: 앱 이름 아래의 14자리 문자열
 - **Client Secret**: 'secret' 항목의 값
-- **Username**: Reddit 사용자명
-- **Password**: Reddit 비밀번호
+- **Refresh Token**: OAuth2 인증 후 발급되는 토큰
 
 ### 3️⃣ Unsplash API 설정 (선택사항)
 
@@ -186,8 +185,7 @@ python install.py
 OPENAI_API_KEY=sk-proj-your-openai-key-here
 REDDIT_CLIENT_ID=your-reddit-client-id
 REDDIT_CLIENT_SECRET=your-reddit-client-secret
-REDDIT_USERNAME=your-reddit-username
-REDDIT_PASSWORD=your-reddit-password
+REDDIT_REFRESH_TOKEN=your-reddit-refresh-token
 
 # 선택적 토큰
 UNSPLASH_ACCESS_KEY=your-unsplash-key

--- a/ORCHESTRATOR_GUIDE.md
+++ b/ORCHESTRATOR_GUIDE.md
@@ -106,8 +106,7 @@ python main.py --status workflow_20231201_120000
 OPENAI_API_KEY=your_openai_api_key
 REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USERNAME=your_reddit_username
-REDDIT_PASSWORD=your_reddit_password
+REDDIT_REFRESH_TOKEN=your_reddit_refresh_token
 
 # 선택적 환경 변수
 UNSPLASH_ACCESS_KEY=your_unsplash_key

--- a/README.md
+++ b/README.md
@@ -111,14 +111,13 @@ cp .env.example .env
 OPENAI_API_KEY=your_openai_key_here
 REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_secret
-REDDIT_USERNAME=your_username
-REDDIT_PASSWORD=your_password
+REDDIT_REFRESH_TOKEN=your_refresh_token
 UNSPLASH_ACCESS_KEY=your_unsplash_key  # 선택사항
 ```
 
 #### 🔑 API 키 발급 가이드
 - **OpenAI**: [platform.openai.com](https://platform.openai.com/) → API Keys
-- **Reddit**: [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps/) → Create App → Script
+- **Reddit**: [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps/) → Create App → Script → OAuth2 인증 후 Refresh Token 발급
 - **Unsplash**: [unsplash.com/developers](https://unsplash.com/developers) → New Application (무료)
 
 ### 3️⃣ 시스템 확인 및 실행

--- a/TOKEN_SETUP_SUMMARY.md
+++ b/TOKEN_SETUP_SUMMARY.md
@@ -64,8 +64,7 @@ python install.py
 1. **OpenAI API Key** - AI 분석용 (유료, 월 $5-10)
 2. **Reddit Client ID** - 트렌드 수집용 (무료)
 3. **Reddit Client Secret** - Reddit API 인증 (무료)
-4. **Reddit Username** - Reddit 계정 (무료)
-5. **Reddit Password** - Reddit 비밀번호 (무료)
+4. **Reddit Refresh Token** - OAuth 인증용 (무료)
 
 ### 🟡 선택적 토큰 (7개)
 1. **Unsplash Access Key** - 이미지 수집 (무료, 월 50회)

--- a/main.py
+++ b/main.py
@@ -71,8 +71,7 @@ def validate_environment():
         'OPENAI_API_KEY': 'OpenAI API (for UX analysis)',
         'REDDIT_CLIENT_ID': 'Reddit API (for trend collection)',
         'REDDIT_CLIENT_SECRET': 'Reddit API (for trend collection)',
-        'REDDIT_USERNAME': 'Reddit API (for trend collection)',
-        'REDDIT_PASSWORD': 'Reddit API (for trend collection)'
+        'REDDIT_REFRESH_TOKEN': 'Reddit API (for trend collection)'
     }
     
     missing_vars = []

--- a/setup_tokens.py
+++ b/setup_tokens.py
@@ -82,27 +82,14 @@ class TokenSetupWizard:
                 ]
             ),
             TokenInfo(
-                name="Reddit Username",
-                env_var="REDDIT_USERNAME",
-                description="Reddit 계정 사용자명",
+                name="Reddit Refresh Token",
+                env_var="REDDIT_REFRESH_TOKEN",
+                description="OAuth 인증을 위한 리프레시 토큰",
                 required=True,
-                get_url="https://www.reddit.com",
+                get_url="https://www.reddit.com/prefs/apps",
                 instructions=[
-                    "1. Reddit 계정의 사용자명 입력",
-                    "2. /u/ 없이 사용자명만 입력",
-                    "3. 예: your_username"
-                ],
-                is_sensitive=False
-            ),
-            TokenInfo(
-                name="Reddit Password",
-                env_var="REDDIT_PASSWORD",
-                description="Reddit 계정 비밀번호",
-                required=True,
-                get_url="https://www.reddit.com",
-                instructions=[
-                    "1. Reddit 계정의 비밀번호 입력",
-                    "2. 2FA 사용 시 앱 전용 비밀번호 생성 필요"
+                    "1. Reddit 앱에서 OAuth2 인증 플로우 진행",
+                    "2. 승인 후 발급되는 refresh token 복사"
                 ]
             ),
             TokenInfo(
@@ -507,8 +494,7 @@ class TokenSetupWizard:
             "OPENAI_API_KEY": lambda v: v.startswith("sk-") and len(v) > 20,
             "REDDIT_CLIENT_ID": lambda v: len(v) > 10 and not v.startswith("your_"),
             "REDDIT_CLIENT_SECRET": lambda v: len(v) > 10 and not v.startswith("your_"),
-            "REDDIT_USERNAME": lambda v: len(v) > 0 and not v.startswith("your_"),
-            "REDDIT_PASSWORD": lambda v: len(v) > 0 and not v.startswith("your_"),
+            "REDDIT_REFRESH_TOKEN": lambda v: len(v) > 20,
             "UNSPLASH_ACCESS_KEY": lambda v: len(v) > 20,
             "SUPABASE_URL": lambda v: v.startswith("https://") and "supabase" in v,
             "SUPABASE_KEY": lambda v: len(v) > 50,

--- a/src/utils/api_clients.py
+++ b/src/utils/api_clients.py
@@ -41,8 +41,7 @@ class RedditClient:
         self.reddit = praw.Reddit(
             client_id=config.get_api_key('reddit_client_id'),
             client_secret=config.get_api_key('reddit_client_secret'),
-            username=os.getenv('REDDIT_USERNAME'),
-            password=os.getenv('REDDIT_PASSWORD'),
+            refresh_token=os.getenv('REDDIT_REFRESH_TOKEN'),
             user_agent=config.get('apis.reddit.user_agent', 'AI App Factory Bot 1.0')
         )
     

--- a/token_manager.py
+++ b/token_manager.py
@@ -42,20 +42,12 @@ class SimpleTokenManager:
                 "example": "xyz789...",
                 "url": "https://www.reddit.com/prefs/apps"
             },
-            "REDDIT_USERNAME": {
-                "name": "Reddit Username",
+            "REDDIT_REFRESH_TOKEN": {
+                "name": "Reddit Refresh Token",
                 "required": True,
-                "description": "Reddit 사용자명",
-                "example": "your_username",
-                "url": "https://www.reddit.com",
-                "sensitive": False
-            },
-            "REDDIT_PASSWORD": {
-                "name": "Reddit Password",
-                "required": True,
-                "description": "Reddit 비밀번호",
-                "example": "your_password",
-                "url": "https://www.reddit.com"
+                "description": "OAuth 인증을 위한 리프레시 토큰",
+                "example": "your_refresh_token",
+                "url": "https://www.reddit.com/prefs/apps"
             },
             
             # 선택적 토큰
@@ -377,8 +369,7 @@ class SimpleTokenManager:
             "OPENAI_API_KEY": lambda v: v.startswith("sk-") and len(v) > 20,
             "REDDIT_CLIENT_ID": lambda v: len(v) > 10,
             "REDDIT_CLIENT_SECRET": lambda v: len(v) > 10,
-            "REDDIT_USERNAME": lambda v: len(v) > 0,
-            "REDDIT_PASSWORD": lambda v: len(v) > 0,
+            "REDDIT_REFRESH_TOKEN": lambda v: len(v) > 20,
             "UNSPLASH_ACCESS_KEY": lambda v: len(v) > 20,
             "SUPABASE_URL": lambda v: v.startswith("https://") and "supabase" in v,
             "SUPABASE_KEY": lambda v: len(v) > 50,


### PR DESCRIPTION
## Summary
- support Reddit OAuth with refresh token instead of password
- update docs and examples to use `REDDIT_REFRESH_TOKEN`
- adjust token manager and setup scripts for new token

## Testing
- `pytest -q` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684bed5382dc832c8e6064b1b2dc33b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reddit API 인증 방식이 기존의 사용자명/비밀번호에서 OAuth 리프레시 토큰 기반으로 변경되었습니다.
- **Documentation**
  - Reddit API 키 및 인증 관련 문서가 리프레시 토큰 사용 방식에 맞게 업데이트되었습니다.
  - 환경 변수 예시와 토큰 설정 안내가 새 인증 방식에 맞게 수정되었습니다.
- **Bug Fixes**
  - 환경 변수 및 토큰 유효성 검사가 새로운 인증 방식에 맞게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->